### PR TITLE
rfc6455 link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![starscream](https://raw.githubusercontent.com/daltoniam/starscream/assets/starscream.jpg)
 
-Starscream is a conforming WebSocket ([RFC 6455](http://tools.ietf.org/html/rfc6455)) library in Swift.
+Starscream is a conforming WebSocket ([RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455)) library in Swift.
 
 ## Features
 


### PR DESCRIPTION
I have fixed an expired link to rfc6455 from http://tools.ietf.org/html/rfc6455 -> https://datatracker.ietf.org/doc/html/rfc6455
